### PR TITLE
bring multichannel support to run_block

### DIFF
--- a/PS6000a.py
+++ b/PS6000a.py
@@ -14,24 +14,24 @@ class PS6000a:
 
     def __init__(self):
 
-        # Create chandle and status ready for use
-        self.chandle = ctypes.c_int16()
+        # Create handle and status ready for use
+        self.handle = ctypes.c_int16()
         self.status = {}
 
         # Open 6000 A series PicoScope
-        # returns handle to chandle for use in API functions
+        # returns handle to handle for use in API functions
         self.resolution = enums.PICO_DEVICE_RESOLUTION['PICO_DR_10BIT']
-        self.status['openunit'] = ps.ps6000aOpenUnit(ctypes.byref(self.chandle), None, self.resolution)
+        self.status['openunit'] = ps.ps6000aOpenUnit(ctypes.byref(self.handle), None, self.resolution)
         assert_pico_ok(self.status['openunit'])
 
     def __del__(self):
-        self.status['stop'] = ps.ps6000aStop(self.chandle)
+        self.status['stop'] = ps.ps6000aStop(self.handle)
         
     def activate_channels(self, channels_on):
 
         self.readout_channels = turnon_readout_channel_DC(
             self.status,
-            self.chandle,
+            self.handle,
             channels_on,
             range_V = '10MV'
         )
@@ -40,7 +40,7 @@ class PS6000a:
         
         set_trigger(
             self.status,
-            self.chandle,
+            self.handle,
             self.readout_channels[channel],
             trigger_thrs_mV = threshold_mV,
             resolution = self.resolution,
@@ -53,7 +53,7 @@ class PS6000a:
         if mode == 'runStreaming':
             sig, time = read_channel_streaming(
                 self.status,
-                self.chandle,
+                self.handle,
                 self.resolution,
                 self.readout_channels,
                 n_pretrigger_samples=n_pretrigger_samples,
@@ -65,7 +65,7 @@ class PS6000a:
         elif mode == 'runBlock':
             sig, time = read_channel_runblock(
                 self.status, 
-                self.chandle,
+                self.handle,
                 self.resolution,
                 self.readout_channels[channel_name],
                 channel_name,

--- a/PS6000a.py
+++ b/PS6000a.py
@@ -36,6 +36,8 @@ class PS6000a:
             range_V = '10MV'
         )
 
+        return self.readout_channels
+        
     def set_trigger(self, threshold_mV, direction, channel = "A"):
         
         set_trigger(
@@ -67,7 +69,7 @@ class PS6000a:
                 self.status, 
                 self.handle,
                 self.resolution,
-                self.readout_channels[channel_name],
+                self.readout_channels,
                 channel_name,
                 n_pretrigger_samples=n_pretrigger_samples,
                 n_posttrigger_samples=n_posttrigger_samples,

--- a/PS6000a.py
+++ b/PS6000a.py
@@ -58,7 +58,7 @@ class PS6000a:
             direction = direction
         )
 
-    def acquire(self, n_pretrigger_samples, n_posttrigger_samples, mode = 'runStreaming'):
+    def acquire(self, n_pretrigger_samples, n_posttrigger_samples, sample_interval_ns, mode = 'runBlock'):
         
         if mode == 'runStreaming':
             sig, time = read_channel_streaming(
@@ -79,6 +79,7 @@ class PS6000a:
                 self.resolution,
                 sources = self.readout_channels,
                 source_ranges = self.channel_ranges,
+                sample_interval_ns = sample_interval_ns,
                 n_pretrigger_samples=n_pretrigger_samples,
                 n_posttrigger_samples=n_posttrigger_samples
             )

--- a/PS6000a.py
+++ b/PS6000a.py
@@ -5,7 +5,7 @@ from picosdk.functions import assert_pico_ok
 
 from .utils import (
     turnon_readout_channel_DC,
-    set_trigger,
+    set_simple_trigger,
     read_channel_streaming,
     read_channel_runblock,
 )
@@ -46,9 +46,9 @@ class PS6000a:
 
         return self.readout_channels
         
-    def set_trigger(self, threshold_mV, direction, channel = "A"):
+    def set_simple_trigger(self, threshold_mV, direction, channel = "A"):
         
-        set_trigger(
+        set_simple_trigger(
             self.status,
             self.handle,
             self.readout_channels[channel],

--- a/utils.py
+++ b/utils.py
@@ -228,7 +228,7 @@ def compose_trigger_DNF(status, handle, autoTriggerMicroSeconds = 0, **kwargs):
     )
     assert_pico_ok(status['setTrigProps'])
 
-def set_simple_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_range, direction = 'RISING_OR_FALLING', dummy = False):
+def set_simple_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_range, direction = 'RISING_OR_FALLING', dummy = False, autoTriggerMicroSeconds = 1000000):
     '''
     Method to setup a trigger
     '''
@@ -255,7 +255,7 @@ def set_simple_trigger(status, handle, source, trigger_thrs_mV, resolution, chan
         mV2adc(trigger_thrs_mV, pico_channel_range, max_ADC),
         pico_direction,
         0,  # delay = 0 s
-        0  # autoTriggerMicroSeconds
+        autoTriggerMicroSeconds
     )
     assert_pico_ok(status['setSimpleTrigger'])
 

--- a/utils.py
+++ b/utils.py
@@ -13,17 +13,17 @@ from picosdk.functions import adc2mV, mV2adc, assert_pico_ok
 
 # for some reasons there is no PICO_CONNECT_PROBE_RANGE in picoEnum
 PICO_CONNECT_PROBE_RANGE = {
-    'PICO_10MV': 1,
-    'PICO_20MV': 2,
-    'PICO_50MV': 3,
-    'PICO_100MV': 4,
-    'PICO_200MV': 5,
-    'PICO_500MV': 6,
-    'PICO_1V': 7,
-    'PICO_2V': 8,
-    'PICO_5V': 9,
-    'PICO_10V': 10,
-    'PICO_20V': 11
+    'PICO_10MV': 0,
+    'PICO_20MV': 1,
+    'PICO_50MV': 2,
+    'PICO_100MV': 3,
+    'PICO_200MV': 4,
+    'PICO_500MV': 5,
+    'PICO_1V': 6,
+    'PICO_2V': 7,
+    'PICO_5V': 8,
+    'PICO_10V': 9,
+    'PICO_20V': 10
 }
 
 def turnon_readout_channel_DC(status, handle, channel_names, channel_ranges, channel_couplings, **kwargs):

--- a/utils.py
+++ b/utils.py
@@ -149,47 +149,61 @@ def set_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_ran
 
     # actual trigger setup starts here
     # set up the trigger channel conditions
-    trigger_cond = structs.PICO_CONDITION(enums.PICO_CHANNEL["PICO_CHANNEL_A"], 
-                                          enums.Pico_TRIGGER_STATE["PICO_CONDITION_TRUE"]
+    trigger_cond_A = structs.PICO_CONDITION(enums.PICO_CHANNEL["PICO_CHANNEL_A"], 
+                                            enums.Pico_TRIGGER_STATE["PICO_CONDITION_TRUE"]
     )
-    status['setTrigConds'] = ps.ps6000aSetTriggerChannelConditions(handle, 
-                                                                   ctypes.byref(trigger_cond), 
-                                                                   1, 
-                                                                   enums.PICO_ACTION['PICO_CLEAR_ALL']
+    trigger_cond_E = structs.PICO_CONDITION(enums.PICO_CHANNEL["PICO_CHANNEL_E"], 
+                                            enums.Pico_TRIGGER_STATE["PICO_CONDITION_TRUE"]
+    )
+    trigger_conds = [trigger_cond_A, trigger_cond_E]
+    pico_trigger_conds = (structs.PICO_CONDITION * len(trigger_conds))(*trigger_conds)
+
+    status['setTrigConds'] = ps.ps6000aSetTriggerChannelConditions(handle,
+                                                                   ctypes.byref(pico_trigger_conds),
+                                                                   len(trigger_conds), 
+                                                                   enums.PICO_ACTION['PICO_ADD'] | enums.PICO_ACTION['PICO_CLEAR_ALL']
     )
     assert_pico_ok(status['setTrigConds'])
-
-    # for channel in ["B"]:
-    #     other_channel = structs.PICO_CONDITION(enums.PICO_CHANNEL[f'PICO_CHANNEL_{channel}'], 
-    #                                            enums.Pico_TRIGGER_STATE["PICO_CONDITION_DONT_CARE"])
-    #     status['setTrigConds'] = ps.ps6000aSetTriggerChannelConditions(handle, ctypes.byref(other_channel), 1, 
-    #                                                                     enums.PICO_ACTION['PICO_ADD'])
-    #     assert_pico_ok(status['setTrigConds'])
     
-    # set the trigger channel directions
-    trigger_dir = structs.PICO_DIRECTION(enums.PICO_CHANNEL["PICO_CHANNEL_A"], 
-                                         enums.PICO_THRESHOLD_DIRECTION["PICO_FALLING"],
-                                         enums.PICO_THRESHOLD_MODE["PICO_LEVEL"]
+    # set the trigger channel directions    
+    trigger_dir_A = structs.PICO_DIRECTION(enums.PICO_CHANNEL["PICO_CHANNEL_A"], 
+                                           enums.PICO_THRESHOLD_DIRECTION["PICO_FALLING"],
+                                           enums.PICO_THRESHOLD_MODE["PICO_LEVEL"]
     )
+    trigger_dir_E = structs.PICO_DIRECTION(enums.PICO_CHANNEL["PICO_CHANNEL_E"], 
+                                           enums.PICO_THRESHOLD_DIRECTION["PICO_FALLING"],
+                                           enums.PICO_THRESHOLD_MODE["PICO_LEVEL"]
+    )
+    trigger_dirs = [trigger_dir_A, trigger_dir_E]
+    pico_trigger_dirs = (structs.PICO_DIRECTION * len(trigger_dirs))(*trigger_dirs)
+
     status['setTrigDir'] = ps.ps6000aSetTriggerChannelDirections(handle,
-                                                                 ctypes.byref(trigger_dir),
-                                                                 1
+                                                                 ctypes.byref(pico_trigger_dirs),
+                                                                 len(trigger_dirs)
     )
     assert_pico_ok(status['setTrigDir'])
 
     # set any additional properties
-    trigger_props = structs.PICO_TRIGGER_CHANNEL_PROPERTIES(trigger_thrs_adc, 
-                                                            trigger_hyst_adc, 
-                                                            trigger_thrs_adc, 
-                                                            trigger_hyst_adc,
-                                                            enums.PICO_CHANNEL["PICO_CHANNEL_A"]
+    trigger_prop_A = structs.PICO_TRIGGER_CHANNEL_PROPERTIES(trigger_thrs_adc, 
+                                                           trigger_hyst_adc, 
+                                                           trigger_thrs_adc, 
+                                                           trigger_hyst_adc,
+                                                           enums.PICO_CHANNEL["PICO_CHANNEL_A"]
     )
+    trigger_prop_E = structs.PICO_TRIGGER_CHANNEL_PROPERTIES(trigger_thrs_adc, 
+                                                           trigger_hyst_adc, 
+                                                           trigger_thrs_adc, 
+                                                           trigger_hyst_adc,
+                                                           enums.PICO_CHANNEL["PICO_CHANNEL_E"]
+    )
+    trigger_props = [trigger_prop_A, trigger_prop_E]
+    pico_trigger_props = (structs.PICO_TRIGGER_CHANNEL_PROPERTIES * len(trigger_props))(*trigger_props)
 
     auxOutputEnable = 0
     autoTriggerMicroSeconds = 0
     status['setTrigProps'] = ps.ps6000aSetTriggerChannelProperties(handle, 
-                                                                   ctypes.byref(trigger_props), 
-                                                                   1, 
+                                                                   ctypes.byref(pico_trigger_props), 
+                                                                   len(trigger_props), 
                                                                    auxOutputEnable, 
                                                                    autoTriggerMicroSeconds
     )

--- a/utils.py
+++ b/utils.py
@@ -127,8 +127,7 @@ def generate_signal(status, handle, func='PICO_SINE', **kwargs):
     )
     assert_pico_ok(status['sigGenApply'])
 
-
-def set_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_range, direction = 'RISING_OR_FALLING', dummy = False):
+def set_simple_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_range, direction = 'RISING_OR_FALLING', dummy = False):
     '''
     Method to setup a trigger
     '''

--- a/utils.py
+++ b/utils.py
@@ -71,7 +71,8 @@ def generate_signal(status, handle, func='PICO_SINE', **kwargs):
     offset_volts = kwargs.get('offset_volts', 0.)
     frequency_hz = kwargs.get('frequency_hz', 10000)
     buffer_length = kwargs.get('buffer_length', 100000)
-    duty_cycle_percent = kwargs.get('duty_cycle_percent', 50.)
+    duty_cycle_percent = kwargs.get('duty_cycle_percent', 50.)    
+    trigger_from_scope = kwargs.get('trigger_from_scope', False)
 
     # Set signal generator waveform
     wavetype = enums.PICO_WAVE_TYPE[func]
@@ -97,19 +98,20 @@ def generate_signal(status, handle, func='PICO_SINE', **kwargs):
     assert_pico_ok(status['sigGenFreq'])
 
     # Set signal generator trigger event
-    status['sigGenTrigger'] = ps.ps6000aSigGenTrigger(
-        handle,
-        enums.PICO_SIGGEN_TRIG_TYPE['PICO_SIGGEN_RISING'],
-        enums.PICO_SIGGEN_TRIG_SOURCE['PICO_SIGGEN_SCOPE_TRIG'],
-        1, # only play a single cycle
-        0 # no auto-trigger
-    )
-    assert_pico_ok(status['sigGenTrigger'])
+    if trigger_from_scope:
+        status['sigGenTrigger'] = ps.ps6000aSigGenTrigger(
+            handle,
+            enums.PICO_SIGGEN_TRIG_TYPE['PICO_SIGGEN_RISING'],
+            enums.PICO_SIGGEN_TRIG_SOURCE['PICO_SIGGEN_SCOPE_TRIG'],
+            1, # only play a single cycle
+            0 # no auto-trigger
+        )
+        assert_pico_ok(status['sigGenTrigger'])
     
     # Apply signal generator settings
     sig_gen_enabled = 1
     sweep_enabled = 0
-    trigger_enabled = 1
+    trigger_enabled = 1 if trigger_from_scope else 0
     auto_clock_opt_enabled = 0
     override_auto_clock_and_prescale = 0
     frequency = ctypes.c_int16(frequency_hz)


### PR DESCRIPTION
Works already:
* different input voltage ranges for each channel
* better selection of timebase (either manual, or the fastest one consistent with the currently enabled channels)

To be included:
* better interface for function generator that also allows to control the triggering

PS: I forgot to edit the git config again ... so it's you who authored all the commits :)