### PR TITLE
WIP: simplify triggering

### DIFF
--- a/PS6000a.py
+++ b/PS6000a.py
@@ -7,7 +7,6 @@ from .utils import (
     turnon_readout_channel_DC,
     compose_trigger_DNF,
     trigger_condition_on_channel,
-    set_simple_trigger,
     read_channel_streaming,
     read_channel_runblock,
     read_channel_rapidblock
@@ -61,17 +60,10 @@ class PS6000a:
         # build a simple AND
         compose_trigger_DNF(self.status, self.handle, conjunction_0 = trigs, autoTriggerMicroSeconds = autoTriggerMicroSeconds)
 
-    def set_simple_trigger(self, threshold_mV, direction, channel = "A"):
-        
-        set_simple_trigger(
-            self.status,
-            self.handle,
-            self.readout_channels[channel],
-            trigger_thrs_mV = threshold_mV,
-            resolution = self.resolution,
-            channel_range = self.channel_ranges[channel],
-            direction = direction
-        )
+    def set_simple_trigger(self, threshold_mV, direction, channel = "A", autoTriggerMicroSeconds = 0):
+
+        self.set_coincidence_trigger(channels = [channel], thresholds_mV = [threshold_mV], directions = [direction],
+                                     autoTriggerMicroSeconds = autoTriggerMicroSeconds)
 
     def acquire(self, sample_interval_ns, mode = 'runBlock', **kwargs):
         

--- a/utils.py
+++ b/utils.py
@@ -229,36 +229,38 @@ def compose_trigger_DNF(status, handle, autoTriggerMicroSeconds = 0, **kwargs):
     )
     assert_pico_ok(status['setTrigProps'])
 
-def set_simple_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_range, direction = 'RISING_OR_FALLING', dummy = False, autoTriggerMicroSeconds = 1000000):
-    '''
-    Method to setup a trigger
-    '''
+# def set_simple_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_range, direction = 'RISING_OR_FALLING', dummy = False, autoTriggerMicroSeconds = 1000000):
+#     '''
+#     Method to setup a trigger on a single channel
+#     '''
+
     
-    # get max ADC value
-    min_ADC = ctypes.c_int16()
-    max_ADC = ctypes.c_int16()
-    status['getAdcLimits'] = ps.ps6000aGetAdcLimits(
-        handle,
-        resolution,
-        ctypes.byref(min_ADC),
-        ctypes.byref(max_ADC)
-    )
-    assert_pico_ok(status['getAdcLimits'])
+    
+    # # get max ADC value
+    # min_ADC = ctypes.c_int16()
+    # max_ADC = ctypes.c_int16()
+    # status['getAdcLimits'] = ps.ps6000aGetAdcLimits(
+    #     handle,
+    #     resolution,
+    #     ctypes.byref(min_ADC),
+    #     ctypes.byref(max_ADC)
+    # )
+    # assert_pico_ok(status['getAdcLimits'])
 
-    # set simple trigger
-    pico_direction = enums.PICO_THRESHOLD_DIRECTION[direction]
-    pico_channel_range = PICO_CONNECT_PROBE_RANGE[channel_range]
+    # # set simple trigger
+    # pico_direction = enums.PICO_THRESHOLD_DIRECTION[direction]
+    # pico_channel_range = PICO_CONNECT_PROBE_RANGE[channel_range]
 
-    status['setSimpleTrigger'] = ps.ps6000aSetSimpleTrigger(
-        handle,
-        0 if dummy else 1,
-        source,
-        mV2adc(trigger_thrs_mV, pico_channel_range, max_ADC),
-        pico_direction,
-        0,  # delay = 0 s
-        autoTriggerMicroSeconds
-    )
-    assert_pico_ok(status['setSimpleTrigger'])
+    # status['setSimpleTrigger'] = ps.ps6000aSetSimpleTrigger(
+    #     handle,
+    #     0 if dummy else 1,
+    #     source,
+    #     mV2adc(trigger_thrs_mV, pico_channel_range, max_ADC),
+    #     pico_direction,
+    #     0,  # delay = 0 s
+    #     autoTriggerMicroSeconds
+    # )
+    # assert_pico_ok(status['setSimpleTrigger'])
 
 
 def read_channel_streaming(status, handle, resolution, sources, **kwargs):

--- a/utils.py
+++ b/utils.py
@@ -649,13 +649,13 @@ def read_channel_runblock(status, handle, resolution, sources, source_ranges, sa
 
     return waveform_mV, time
 
-def adc2mV_fast(bufferADC, range, maxADC):
+def adc2mV_fast(bufferADC, channel_range, maxADC):
 
     if not isinstance(bufferADC, np.ndarray):
         bufferADC = np.array(bufferADC)
 
     channelInputRanges = [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000]
-    vRange = channelInputRanges[range]
-    bufferV = bufferADC * vRange / maxADC.value
+    vRange = channelInputRanges[channel_range]
+    bufferV = (1.0 * bufferADC) * vRange / maxADC.value
 
     return bufferV

--- a/utils.py
+++ b/utils.py
@@ -229,40 +229,6 @@ def compose_trigger_DNF(status, handle, autoTriggerMicroSeconds = 0, **kwargs):
     )
     assert_pico_ok(status['setTrigProps'])
 
-# def set_simple_trigger(status, handle, source, trigger_thrs_mV, resolution, channel_range, direction = 'RISING_OR_FALLING', dummy = False, autoTriggerMicroSeconds = 1000000):
-#     '''
-#     Method to setup a trigger on a single channel
-#     '''
-
-    
-    
-    # # get max ADC value
-    # min_ADC = ctypes.c_int16()
-    # max_ADC = ctypes.c_int16()
-    # status['getAdcLimits'] = ps.ps6000aGetAdcLimits(
-    #     handle,
-    #     resolution,
-    #     ctypes.byref(min_ADC),
-    #     ctypes.byref(max_ADC)
-    # )
-    # assert_pico_ok(status['getAdcLimits'])
-
-    # # set simple trigger
-    # pico_direction = enums.PICO_THRESHOLD_DIRECTION[direction]
-    # pico_channel_range = PICO_CONNECT_PROBE_RANGE[channel_range]
-
-    # status['setSimpleTrigger'] = ps.ps6000aSetSimpleTrigger(
-    #     handle,
-    #     0 if dummy else 1,
-    #     source,
-    #     mV2adc(trigger_thrs_mV, pico_channel_range, max_ADC),
-    #     pico_direction,
-    #     0,  # delay = 0 s
-    #     autoTriggerMicroSeconds
-    # )
-    # assert_pico_ok(status['setSimpleTrigger'])
-
-
 def read_channel_streaming(status, handle, resolution, sources, **kwargs):
     '''
     Method to read out a signal with given source channels using the straming functionality


### PR DESCRIPTION
Hi @fgrosa,

Before testing all your new code for the online DCR measurement, I wanted to clean up a bit.

I remove the original `set_simple_trigger` function, whose functionality is now covered by the more general `set_coincidence_trigger` (a coincidence trigger on a single channel is just a simple trigger).

I also fixed an overflow problem in the fast adc2mV conversion routine.

I will keep this as WIP for now & will remove it when I tested everything together in the DCR measurement.

Philipp